### PR TITLE
zcbor_bstr_start_decode: fix NULL result handling

### DIFF
--- a/src/zcbor_decode.c
+++ b/src/zcbor_decode.c
@@ -316,8 +316,8 @@ static bool str_overflow_check(zcbor_state_t *state, struct zcbor_string *result
 
 bool zcbor_bstr_start_decode(zcbor_state_t *state, struct zcbor_string *result)
 {
+	struct zcbor_string dummy;
 	if (result == NULL) {
-		struct zcbor_string dummy;
 		result = &dummy;
 	}
 


### PR DESCRIPTION
Commit 18f78c575f6f6df20c9c85f1260b12099d5ef67e
("zcbor.py: Remove unused types and members.")
introduced null handling for the result argument in
zcbor_bstr_start_decode().

However, in this implementation, if result is initially NULL,
then it will end up pointing to the location of a stack
variable allocated in a block which has gone out of scope
by the time it is used. This is unsafe; fix it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>