### PR TITLE
tests: Replace global CSTD property with Kconfig symbol

### DIFF
--- a/tests/decode/test2_suit/CMakeLists.txt
+++ b/tests/decode/test2_suit/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test2_suit)
 include(../../cmake/test_template.cmake)

--- a/tests/decode/test2_suit/prj.conf
+++ b/tests/decode/test2_suit/prj.conf
@@ -7,3 +7,5 @@
 CONFIG_ZTEST=y
 CONFIG_ZTEST_NEW_API=y
 CONFIG_ZTEST_STACK_SIZE=16384
+# To avoid issues with c99 and -Wpedantic
+CONFIG_STD_C11=y

--- a/tests/decode/test5_corner_cases/CMakeLists.txt
+++ b/tests/decode/test5_corner_cases/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test5_corner_cases)
 include(../../cmake/test_template.cmake)

--- a/tests/decode/test5_corner_cases/prj.conf
+++ b/tests/decode/test5_corner_cases/prj.conf
@@ -7,3 +7,5 @@
 CONFIG_ZTEST=y
 CONFIG_ZTEST_NEW_API=y
 CONFIG_ZTEST_STACK_SIZE=4096
+# To avoid issues with c99 and -Wpedantic
+CONFIG_STD_C11=y

--- a/tests/encode/test4_senml/CMakeLists.txt
+++ b/tests/encode/test4_senml/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test4_senml)
 include(../../cmake/test_template.cmake)

--- a/tests/encode/test4_senml/prj.conf
+++ b/tests/encode/test4_senml/prj.conf
@@ -7,3 +7,5 @@
 CONFIG_ZTEST=y
 CONFIG_ZTEST_NEW_API=y
 CONFIG_ZTEST_STACK_SIZE=4096
+# To avoid issues with c99 and -Wpedantic
+CONFIG_STD_C11=y

--- a/tests/unit/test1_unit_tests/CMakeLists.txt
+++ b/tests/unit/test1_unit_tests/CMakeLists.txt
@@ -6,8 +6,6 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-set_property(GLOBAL PROPERTY CSTD c11) # To avoid issues with c99 and -Wpedantic
-
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(test1_unit_tests)
 include(../../cmake/test_template.cmake)

--- a/tests/unit/test1_unit_tests/prj.conf
+++ b/tests/unit/test1_unit_tests/prj.conf
@@ -7,3 +7,5 @@
 CONFIG_ZTEST=y
 CONFIG_ZTEST_NEW_API=y
 CONFIG_ZTEST_STACK_SIZE=4096
+# To avoid issues with c99 and -Wpedantic
+CONFIG_STD_C11=y


### PR DESCRIPTION
Due to upstream change in standard C selection, a Kconfig symbol should be selected instead of using a global property.